### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Verify
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/minter/rod_the_bot/security/code-scanning/2](https://github.com/minter/rod_the_bot/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs local Ruby commands (build, lint, audit), it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This block should be added at the top level of the workflow file (just after the `name` or `on` key), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
